### PR TITLE
Consertar forma da variável das redes sociais

### DIFF
--- a/_layouts/website/social_medias.html
+++ b/_layouts/website/social_medias.html
@@ -31,7 +31,26 @@
 </div>
 
 {% for socialMedia in book.socialNetworks.medias %}
-  <a class="btn pull-right" aria-label="" href="{{ socialMedia.url }}">
-    <i class="fa fa-{{ socialMedia.icon }}"></i>
-  </a>
+  {% if socialMedia.url %}
+    <a class="btn pull-right" aria-label="" href="{{ socialMedia.url }}" target="_blank">
+      <i class="fa fa-{{ socialMedia.icon }}"></i>
+    </a>
+
+  {% else %} 
+  
+    {% if socialMedia.links %}
+      <div class="dropdown pull-right">
+        <a class="btn toggle-dropdown" href="#">
+          <i class="fa fa-{{ socialMedia.icon }}"></i>
+        </a>
+        <div class="dropdown-menu dropdown-left">
+          {% for link in socialMedia.links %}
+            <a href="{{ link.url }}" class="button size-5" target="_blank">
+              {{ link.name }}
+            </a>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  {% endif %}
 {% endfor %}

--- a/book.json
+++ b/book.json
@@ -8,15 +8,11 @@
           "icon": "facebook"
         },
         {
-          "name": "Twitter Jeferson",
-          "url": "https://twitter.com/badtux_",
-          "icon": "twitter",
-          "sharing": true,
-          "sharingBaseUrl": "https://twitter.com/intent/tweet?text=:text&url=:url"
-        },
-        {
-          "name": "Twitter LINUXtips",
-          "url": "https://twitter.com/LINUXtipsBR",
+          "name": "Twitter",
+          "links": [
+            { "url": "https://twitter.com/badtux_", "name": "Jeferson" },
+            { "url": "https://twitter.com/LINUXtipsBR", "name": "LINUXtips" }
+          ],
           "icon": "twitter",
           "sharing": true,
           "sharingBaseUrl": "https://twitter.com/intent/tweet?text=:text&url=:url"


### PR DESCRIPTION
A o objeto `socialNetworks.medias` agora permite um atributo `:url` para linkar um único perfil ou `:links`, onde é possível passar a url e o nome para ser exibido num dropdown.

O template do cabeçalho também foi ajustado para comportar este novo estilo.