### PR TITLE
Corrige o Dockerfile para build do goapp

### DIFF
--- a/chapters/chapter_08.md
+++ b/chapters/chapter_08.md
@@ -360,7 +360,7 @@ WORKDIR /app
 
 ADD . /app
 
-RUN go build -o goapp
+RUN go mod init goapp && go build -o goapp
 
 ENTRYPOINT ./goapp
 ```


### PR DESCRIPTION
Adiciona ```RUN go mod init goapp && go build -o goapp``` para inicializar o app evitar o retorno abaixo:

```bash
$ docker image build -t go-app:0.1.0 .
Sending build context to Docker daemon  2.013MB
Step 1/5 : FROM golang
 ---> 20a4005814ee
Step 2/5 : WORKDIR /app
 ---> Using cache
 ---> 243e46666db7
Step 3/5 : ADD . /app
 ---> 907c95e93c94
Step 4/5 : RUN go build -o goapp
 ---> Running in a10345e919ff
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
The command '/bin/sh -c go build -o goapp' returned a non-zero code: 1
```