### PR TITLE
Altera a imagem base para o debian:10

### DIFF
--- a/chapters/chapter_08.md
+++ b/chapters/chapter_08.md
@@ -58,7 +58,7 @@ adicionar o conteúdo conforme exemplo a seguir:
 ```
 
 ```Dockerfile
-FROM debian
+FROM debian:10
 
 RUN apt-get update && apt-get install -y apache2 && apt-get clean
 
@@ -213,7 +213,7 @@ A primeira coisa é deixar o nosso *dockerfile* como segue:
 ```
 
 ```Dockerfile
-FROM debian
+FROM debian:10
 
 RUN apt-get update && apt-get install -y apache2 && apt-get clean
 


### PR DESCRIPTION
Adiciona a tag "10" para a imagem base do debian, pois a imagem latest não traz o pacote iproute2, necessário para os exemplos  `ss -atn` e `ip addr show eth0` presentes no capítulo.
